### PR TITLE
docs: add code quality and CI conventions to SDK docs (phase 2)

### DIFF
--- a/docs/manual/building_your_first_integration.md
+++ b/docs/manual/building_your_first_integration.md
@@ -406,6 +406,17 @@ async with ExecutionContext(auth=auth) as context:
 
 > **Note:** In production, the platform wraps credentials as `{"auth_type": "...", "credentials": {"api_token": "..."}}`. That's why production action handlers access `context.auth.get("credentials", {}).get("api_token")`. When testing locally with `execute_action`, the SDK validates `context.auth` directly against your `auth.fields` schema, so pass credentials flat.
 
+For **platform OAuth** integrations (where `context.fetch()` auto-injects the Bearer token), pass the full wrapped structure in tests:
+
+```python
+auth = {
+    "auth_type": "PlatformOauth2",
+    "credentials": {"access_token": "your-test-token"}
+}
+async with ExecutionContext(auth=auth) as context:
+    result = await my_integration.execute_action("list_repos", inputs, context)
+```
+
 ## Multi-File Integrations
 
 For integrations with many actions, split handlers into an `actions/` directory:

--- a/docs/manual/patterns.md
+++ b/docs/manual/patterns.md
@@ -237,3 +237,74 @@ def get_headers(context: ExecutionContext) -> Dict[str, str]:
 ```
 
 This pattern is used by integrations like Freshdesk (API key + domain), Trello (API key + token), and Google Looker (base URL + client ID + client secret).
+
+## Code Quality Conventions
+
+### Constants and Configuration
+
+Define API base URLs, version strings, and other constants at module level:
+
+```python
+BASE_URL = "https://api.example.com/v2"
+API_VERSION = "v2"
+DEFAULT_PAGE_SIZE = 100
+```
+
+### Type Hints
+
+Add type hints to all function parameters and return types:
+
+```python
+async def execute(self, inputs: Dict[str, Any], context: ExecutionContext) -> ActionResult:
+    ...
+```
+
+### Credentials
+
+Never hardcode API keys, tokens, or secrets. Always read them from `context.auth`:
+
+```python
+# WRONG
+headers = {"Authorization": "Bearer sk-abc123"}
+
+# CORRECT
+credentials = context.auth.get("credentials", {})
+api_key = credentials.get("api_key", "")
+headers = {"Authorization": f"Bearer {api_key}"}
+```
+
+## Linting and CI
+
+Integration repos use the [autohive-integrations-tooling](https://github.com/Autohive-AI/autohive-integrations-tooling) CI pipeline. Understanding the lint configuration helps avoid common CI failures.
+
+### Ruff Rules
+
+CI runs [ruff](https://docs.astral.sh/ruff/) with rules `E` (pycodestyle errors), `F` (pyflakes), and `W` (pycodestyle warnings). Line length is 120 characters. Target version is Python 3.13.
+
+### Per-File Lint Suppressions
+
+The tooling repo's `ruff.toml` automatically suppresses certain rules for specific files:
+
+| File | Suppressed | Why |
+|------|-----------|-----|
+| `__init__.py` | `F401` (unused import) | Import-and-re-export is the expected pattern |
+| `tests/context.py` | `F401` (unused import), `E402` (import not at top of file) | The `sys.path` setup must come before the integration import |
+
+This means you **don't** need `# noqa` comments in these two files. However, if you have intentional "unused" imports in other files (e.g., re-exporting from a helpers module), you must add `# noqa: F401` inline:
+
+```python
+# helpers.py — re-exporting for convenience
+from .utils import format_date, parse_response  # noqa: F401
+```
+
+### Security Scanning
+
+CI runs [bandit](https://bandit.readthedocs.io/) for security checks. It skips rule `B101` (assert_used), so assertions in test files are fine. Common bandit flags to watch for:
+
+- `B105` / `B106` — hardcoded passwords or credentials
+- `B108` — insecure temp file usage
+- `B310` — `urllib.urlopen` with user-controlled input
+
+### Dependency Auditing
+
+CI runs `pip-audit` against your `requirements.txt` to check for known CVEs. If a dependency has a vulnerability, update to the fixed version listed in the audit output.


### PR DESCRIPTION
Companion to the tooling repo Phase 2 PR. Adds content to SDK docs that was previously only in the tooling repo's checklist.

## Changes

### docs/manual/patterns.md (+71 lines)

- Code Quality Conventions: constants at module level, type hints, never hardcode credentials
- Linting and CI: ruff rules (E/F/W), per-file suppressions table, # noqa guidance, bandit config (B101 skipped), common bandit flags, pip-audit

### docs/manual/building_your_first_integration.md (+11 lines)

- Platform OAuth test example showing wrapped auth structure alongside flat custom auth example

## Related

- SDK Phase 1 PR: #13
- Tooling Phase 2 PR: https://github.com/Autohive-AI/autohive-integrations-tooling/pull/16