### PR TITLE
docs: remove name-folder match rule, mark display_name as recommended

### DIFF
--- a/docs/manual/building_your_first_integration.md
+++ b/docs/manual/building_your_first_integration.md
@@ -118,7 +118,7 @@ For public APIs that don't require authentication:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Integration identifier (lowercase) |
+| `name` | string | Integration name |
 | `version` | string | Semantic version (`MAJOR.MINOR.PATCH`) |
 | `description` | string | What the integration does |
 | `entry_point` | string | Main Python file name (must end in `.py`) |

--- a/docs/manual/integration_structure.md
+++ b/docs/manual/integration_structure.md
@@ -92,7 +92,7 @@ Add any additional libraries your integration needs (e.g., `feedparser`, `stripe
 | Directory name | lowercase, hyphens | `my-integration`, `google-sheets` |
 | Python module | lowercase, underscores | `my_integration.py`, `google_sheets.py` |
 | Action names | snake_case | `list_items`, `create_record` |
-| `config.json` `name` | lowercase, hyphens | `my-integration` |
+| `config.json` `name` | human-readable name | `My Integration` |
 
 ## `config.json` Schema
 
@@ -102,7 +102,7 @@ Add any additional libraries your integration needs (e.g., `feedparser`, `stripe
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Integration identifier (lowercase) |
+| `name` | string | Integration name |
 | `version` | string | Semantic version (`MAJOR.MINOR.PATCH`, e.g., `"1.0.0"`) |
 | `description` | string | What the integration does |
 | `entry_point` | string | Main Python file name (e.g., `"my_integration.py"`) |


### PR DESCRIPTION
## Context

Follows from [autohive-integrations-tooling PR #21](https://github.com/Autohive-AI/autohive-integrations-tooling/pull/21) which:
1. Removed the validation check requiring `config.json` `name` to match the directory name
2. Added a warning when top-level `display_name` is missing or empty

## Changes

### `docs/manual/integration_structure.md`
- Naming conventions table: removed "must match directory name" constraint
- Removed prose sentence about tooling validating name-folder match
- Required fields table: removed "matches directory name" from `name` description
- Optional fields table: marked `display_name` as "(recommended)"

### `docs/manual/building_your_first_integration.md`
- Optional fields table: marked `display_name` as "(recommended)"

Closes #21