### PR TITLE
Export HTTPError and RateLimitError from package

### DIFF
--- a/src/autohive_integrations_sdk/__init__.py
+++ b/src/autohive_integrations_sdk/__init__.py
@@ -4,5 +4,6 @@ __version__ = "1.1.0"
 # Re-export classes from integration module
 from autohive_integrations_sdk.integration import (
     Integration, ExecutionContext, ActionHandler, PollingTriggerHandler, ConnectedAccountHandler,
-    ConnectedAccountInfo, ValidationError, ActionResult, ActionError, IntegrationResult, ResultType
+    ConnectedAccountInfo, ValidationError, HTTPError, RateLimitError,
+    ActionResult, ActionError, IntegrationResult, ResultType
 )


### PR DESCRIPTION
## Export HTTPError and RateLimitError from package

### Description :memo:
- **Purpose**: Allow integrations to catch and handle HTTP errors raised by `ExecutionContext.fetch()` without reaching into internal modules.
- **Approach**: Add `HTTPError` and `RateLimitError` to the package's `__init__.py` re-exports.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Updates**

:point_right: Export `HTTPError` from the top-level package (raised on non-2xx responses)
:point_right: Export `RateLimitError` from the top-level package (raised on HTTP 429, subclass of `HTTPError`)

### Screenshots :camera:
N/A

### Test plan :test_tube:
- Verify `from autohive_integrations_sdk import HTTPError, RateLimitError` works
- Verify existing imports are unaffected (non-breaking, additive only)

### Author(s) to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer(s) to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)