### PR TITLE
chore: release 1.1.1

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 1.1.1
+- Export HTTPError and RateLimitError from package for direct import
+- Added PyPI-optimised README with absolute links and best practices
+- Documentation: updated SDK version pins and compatible release ranges
+
 ## 1.1.0
 - Add ActionError for expected application-level errors
 - Documentation improvements: unified integration docs, billing/cost tracking manual, code quality conventions, integration callouts linked to source code

--- a/docs/manual/building_your_first_integration.md
+++ b/docs/manual/building_your_first_integration.md
@@ -44,10 +44,10 @@ cd my-integration
 Create a `requirements.txt`:
 
 ```
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.1
 ```
 
-The `~=` (compatible release) operator means `>=1.0.2, <1.1.0` — you'll get patch updates with bug fixes, but won't be surprised by minor version changes that could alter SDK behaviour.
+The `~=` (compatible release) operator means `>=1.1.1, <1.2.0` — you'll get patch updates with bug fixes, but won't be surprised by minor version changes that could alter SDK behaviour.
 
 Add any additional libraries your integration needs beyond the SDK (e.g., `feedparser` for RSS parsing, `stripe` for the Stripe client library).
 

--- a/docs/manual/integration_structure.md
+++ b/docs/manual/integration_structure.md
@@ -78,10 +78,10 @@ In this pattern:
 Must include the SDK with a compatible release pin:
 
 ```
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=1.1.1
 ```
 
-The `~=` operator means `>=1.0.2, <1.1.0` — you get patch updates but not minor version changes.
+The `~=` operator means `>=1.1.1, <1.2.0` — you get patch updates but not minor version changes.
 
 Add any additional libraries your integration needs (e.g., `feedparser`, `stripe`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autohive_integrations_sdk"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name="Hamish Taylor", email="hamish@autohive.com" },
   { name="Reilly Oldham", email="reilly@autohive.com" },

--- a/src/autohive_integrations_sdk/__init__.py
+++ b/src/autohive_integrations_sdk/__init__.py
@@ -1,5 +1,5 @@
 # Version
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # Re-export classes from integration module
 from autohive_integrations_sdk.integration import (


### PR DESCRIPTION
## Release 1.1.1

### Changes

- **Export HTTPError and RateLimitError** — allow integrations to catch and handle HTTP errors raised by `ExecutionContext.fetch()` via direct import (#26)
- **PyPI-optimised README** — dedicated `README_PYPI.md` with absolute links, install instructions, and quick code example (#25)
- **Documentation** — updated SDK version pins and compatible release ranges to `~=1.1.1`

### Release checklist

- [x] Version bumped in `pyproject.toml`
- [x] Version bumped in `__init__.py`
- [x] `RELEASENOTES.md` updated
- [x] Documentation version references updated
- [x] Package built successfully (`autohive_integrations_sdk-1.1.1`)
- [x] All public exports verified
- [ ] Publish to PyPI