### PR TITLE
fix: update sample requirements.txt to pin SDK ~=2.0.0

### DIFF
--- a/samples/action-error-demo/requirements.txt
+++ b/samples/action-error-demo/requirements.txt
@@ -1,1 +1,1 @@
-autohive_integrations_sdk
+autohive-integrations-sdk~=2.0.0

--- a/samples/api-fetch/requirements.txt
+++ b/samples/api-fetch/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0

--- a/samples/template/requirements.txt
+++ b/samples/template/requirements.txt
@@ -1,1 +1,1 @@
-autohive-integrations-sdk~=1.0.2
+autohive-integrations-sdk~=2.0.0


### PR DESCRIPTION
All three sample integrations had stale SDK version pins that didn't match the released 2.0.0 version:

- `samples/template/requirements.txt` — `~=1.0.2` → `~=2.0.0`
- `samples/api-fetch/requirements.txt` — `~=1.0.2` → `~=2.0.0`
- `samples/action-error-demo/requirements.txt` — unpinned → `~=2.0.0`

The sample code itself already uses the v2 `FetchResponse.data` pattern — only the pins were stale.