### PR TITLE
docs: update SDK version references from ~=1.1.1 to ~=2.0.0

### DIFF
--- a/docs/manual/building_your_first_integration.md
+++ b/docs/manual/building_your_first_integration.md
@@ -44,10 +44,10 @@ cd my-integration
 Create a `requirements.txt`:
 
 ```
-autohive-integrations-sdk~=1.1.1
+autohive-integrations-sdk~=2.0.0
 ```
 
-The `~=` (compatible release) operator means `>=1.1.1, <1.2.0` — you'll get patch updates with bug fixes, but won't be surprised by minor version changes that could alter SDK behaviour.
+The `~=` (compatible release) operator means `>=2.0.0, <2.1.0` — you'll get patch updates with bug fixes, but won't be surprised by minor version changes that could alter SDK behaviour.
 
 Add any additional libraries your integration needs beyond the SDK (e.g., `feedparser` for RSS parsing, `stripe` for the Stripe client library).
 

--- a/docs/manual/integration_structure.md
+++ b/docs/manual/integration_structure.md
@@ -78,10 +78,10 @@ In this pattern:
 Must include the SDK with a compatible release pin:
 
 ```
-autohive-integrations-sdk~=1.1.1
+autohive-integrations-sdk~=2.0.0
 ```
 
-The `~=` operator means `>=1.1.1, <1.2.0` — you get patch updates but not minor version changes.
+The `~=` operator means `>=2.0.0, <2.1.0` — you get patch updates but not minor version changes.
 
 Add any additional libraries your integration needs (e.g., `feedparser`, `stripe`).
 


### PR DESCRIPTION
Updates the recommended SDK version pin in the two manual docs from `~=1.1.1` to `~=2.0.0`:

- `docs/manual/building_your_first_integration.md`
- `docs/manual/integration_structure.md`