### PR TITLE
docs(skills): clarify version bump scope and add conftest.py to test structure

### DIFF
--- a/skills/upgrading-sdk-v2/SKILL.md
+++ b/skills/upgrading-sdk-v2/SKILL.md
@@ -130,6 +130,8 @@ Increment the **major** version since the SDK dependency is a breaking change:
 
 If the integration was already at a higher version (e.g. `1.1.0`), bump to `2.0.0`.
 
+> **This step only applies to existing integrations being upgraded.** A brand-new integration written directly against SDK 2.0.0 should start at `"version": "1.0.0"` — the integration's own version reflects its release history, not the SDK version.
+
 ### Step 5 — Update unit tests (if they exist)
 
 **A. Wrap fetch mocks in FetchResponse:**
@@ -256,7 +258,7 @@ Before considering an integration upgraded, verify:
 - [ ] `ActionError` is imported from the SDK
 - [ ] `"error"` and error-only `"result"` properties removed from output schemas in `config.json`
 - [ ] `requirements.txt` pins `autohive-integrations-sdk~=2.0.0`
-- [ ] `config.json` version is bumped to `2.0.0`
+- [ ] `config.json` version is bumped to `2.0.0` (upgrades only — new integrations stay at `1.0.0`)
 - [ ] Unit test mocks wrap return values in `FetchResponse(...)`
 - [ ] Unit test error assertions use `result.type == ResultType.ACTION_ERROR` and `result.result.message`
 - [ ] `pytest.raises(ValidationError)` replaced with `result.type == ResultType.VALIDATION_ERROR`

--- a/skills/writing-unit-tests/SKILL.md
+++ b/skills/writing-unit-tests/SKILL.md
@@ -21,6 +21,7 @@ For small integrations (1–10 actions), a single file is fine:
 ```
 myintegration/tests/
 ├── __init__.py
+├── conftest.py
 └── test_myintegration_unit.py
 ```
 
@@ -29,6 +30,7 @@ For large integrations (10+ actions), split by domain:
 ```
 hubspot/tests/
 ├── __init__.py
+├── conftest.py
 ├── test_hubspot_helpers_unit.py
 ├── test_hubspot_contacts_unit.py
 ├── test_hubspot_companies_unit.py
@@ -36,6 +38,18 @@ hubspot/tests/
 ├── test_hubspot_notes_unit.py
 ├── test_hubspot_tickets_unit.py
 └── test_hubspot_misc_unit.py
+```
+
+### conftest.py
+
+Every `tests/` directory should include a `conftest.py` with this standard content:
+
+```python
+import sys
+import os
+
+# Allow 'from context import ...' to work when pytest runs from repo root
+sys.path.insert(0, os.path.dirname(__file__))
 ```
 
 The `_unit.py` suffix is required — CI uses it to discover unit tests.


### PR DESCRIPTION
## Summary

Two skill doc improvements discovered while reviewing [autohive-integrations PR #271](https://github.com/autohive-ai/autohive-integrations/pull/271) (Salesforce integration):

### upgrading-sdk-v2
- **Step 4** and the **checklist** said to bump `config.json` version to `2.0.0` unconditionally. This caused a false finding when reviewing a brand-new integration written directly against SDK 2.0.0 — the agent incorrectly flagged `"version": "1.0.0"` as wrong.
- Added a callout clarifying this only applies to **existing integrations being upgraded**, not new ones. New integrations should start at `1.0.0`.

### writing-unit-tests
- The file structure examples omitted `conftest.py`, which caused the agent to flag it as "non-standard" during review. In reality, every integration in the repo has a `conftest.py` with identical content (including all four reference integrations: hubspot, bitly, hackernews, perplexity).
- Added `conftest.py` to both file structure examples and documented its standard content.