### PR TITLE
docs: add integration PR review skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -7,6 +7,8 @@ Agent skills for AI coding assistants (Amp, Claude Code, etc.) that automate com
 | Skill | Description |
 |-------|-------------|
 | [`building-integration/`](building-integration/) | Runs the local build and validation pipeline (structure, lint, format, security, tests) |
+| [`migrating-private-integration/`](migrating-private-integration/) | Migrates an integration from the private repo to the public integrations repo |
+| [`reviewing-integration-prs/`](reviewing-integration-prs/) | Reviews integration PRs for code quality, security, tests, docs, and skill compliance |
 | [`upgrading-sdk-v2/`](upgrading-sdk-v2/) | Upgrades an integration from SDK 1.x to 2.0.0 |
 | [`writing-unit-tests/`](writing-unit-tests/) | Writes pytest unit tests for an integration using mock_context + FetchResponse |
 | [`writing-integration-tests/`](writing-integration-tests/) | Writes pytest e2e integration tests that call real APIs using the live_context fixture |
@@ -46,6 +48,7 @@ Once installed, the skill is automatically available. You can invoke it by:
 
 - Asking your agent to "upgrade this integration to SDK v2"
 - Asking to "migrate to SDK 2.0.0"
+- Asking to "review this integration PR" or "validate this PR against our skills"
 - Explicitly: "use the upgrading-sdk-v2 skill on the bitly integration"
 
 The agent will load the skill's instructions and follow the step-by-step workflow.

--- a/skills/reviewing-integration-prs/SKILL.md
+++ b/skills/reviewing-integration-prs/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: reviewing-integration-prs
+description: "Reviews Autohive integration pull requests for code quality, security, tests, docs, and compliance with the integration skills. Use when asked to review an integration PR, validate work against skills, or assess integration changes before merge."
+---
+
+# Reviewing Integration PRs
+
+Use this skill to perform a structured review of pull requests in `Autohive-AI/autohive-integrations` and related integration migration/upgrade PRs.
+
+The goal is not just a generic code review. Validate the PR against the relevant integration skills, the tooling checks, and the security expectations for public integrations.
+
+## Review Principles
+
+- Review the actual diff and the surrounding integration code; do not rely only on CI status.
+- Treat security and secret leakage as blockers.
+- Treat failed tooling/validation as blockers unless there is a documented, intentional exception.
+- Use the existing skills as sub-skill checklists when their context applies.
+- Prefer actionable review comments with file/line references and concrete fixes.
+- Separate blockers from should-fix items and minor suggestions.
+
+## Sub-skills to Apply
+
+Apply these existing skills when the PR touches their area:
+
+| Context in PR | Apply this skill/checklist |
+|---|---|
+| Any integration implementation, config, README, or tests changed | `building-integration` |
+| Unit tests added or changed | `writing-unit-tests` |
+| Integration tests added or changed | `writing-integration-tests` |
+| `requirements.txt` changes SDK 1.x → 2.x, or fetch handling changes | `upgrading-sdk-v2` |
+| Private → public migration, copied integration, public publishing | `migrating-private-integration` |
+
+When reviewing, explicitly say which sub-skill contexts applied. Example: “Applied: building-integration, writing-integration-tests.”
+
+## Review Workflow
+
+### 1. Understand the PR scope
+
+Identify:
+
+- Changed integration directories.
+- Whether this is a new integration, existing integration change, SDK upgrade, migration, test-only change, or docs-only change.
+- Changed files: `config.json`, source `.py`, `requirements.txt`, `README.md`, `tests/`, icons, repo-level `README.md`, root `.env.example`.
+- Whether the PR introduces or changes integration tests that need real credentials.
+
+Useful commands when reviewing locally:
+
+```bash
+git diff --name-status origin/master...HEAD
+python ../autohive-integrations-tooling/scripts/get_changed_dirs.py origin/master
+```
+
+### 2. Run or inspect tooling validation
+
+For changed integration directories, verify the same checks CI runs:
+
+```bash
+DIRS=$(python ../autohive-integrations-tooling/scripts/get_changed_dirs.py origin/master)
+python ../autohive-integrations-tooling/scripts/validate_integration.py $DIRS
+python ../autohive-integrations-tooling/scripts/check_code.py --base-ref origin/master $DIRS
+python ../autohive-integrations-tooling/scripts/run_tests.py $DIRS
+python ../autohive-integrations-tooling/scripts/check_readme.py origin/master $DIRS
+python ../autohive-integrations-tooling/scripts/check_version_bump.py origin/master $DIRS
+```
+
+If you cannot run these, inspect CI logs or state clearly that validation was not run.
+
+Do not stop at “CI is green.” Still inspect the diff for security, auth, schema, test, and documentation quality.
+
+### 3. General code quality and style
+
+Check for:
+
+- Clear action handler structure and idiomatic SDK usage.
+- `config.json` action names matching `@integration.action("...")` decorators.
+- Input schema matching code usage and required/optional behavior.
+- Output schema matching successful action outputs.
+- No broad, swallowed exceptions that hide real failures without returning `ActionError`.
+- Good helper boundaries without unnecessary abstractions.
+- No dead code, debug prints, temporary files, vendored dependencies, or generated artifacts.
+- Ruff-compatible formatting and imports.
+
+Common blockers:
+
+- Source action exists but is missing from `config.json`, or vice versa.
+- New integration has config/input drift.
+- Required file missing: `config.json`, `requirements.txt`, `README.md`, icon, tests folder.
+- SDK dependency missing or unpinned.
+- Action output returns fields not described in `output_schema` for success cases.
+
+### 4. Security and public-safety review
+
+Check for:
+
+- No real tokens, API keys, passwords, refresh tokens, JWTs, private keys, service-account JSON, or bearer tokens.
+- No committed `.env`, `.env.*`, credential files, secret dumps, local config, or screenshots with secrets.
+- No customer data, employee names/emails, internal Autohive hostnames, staging URLs, Slack/Notion/internal links, or private repo references.
+- No hardcoded test resource IDs that expose real customer data; prefer env vars for live integration tests.
+- No unsafe calls such as `eval`, `exec`, shelling out with user input, insecure temp files, or unbounded file/network operations.
+- Auth handling returns user-facing `ActionError` where possible instead of leaking low-level exceptions.
+- OAuth scopes are minimal for the implemented actions.
+
+For migrations to public, apply the `migrating-private-integration` security/safety/secrets checklist. Security review should be explicit in the PR body.
+
+### 5. Tests and `.env.example`
+
+For unit tests, apply `writing-unit-tests`:
+
+- Tests are named `test_*_unit.py`.
+- They use `mock_context`, `make_context`, and `FetchResponse` correctly for SDK 2.x.
+- They cover happy paths, request shape, validation/error paths, edge cases, and response shape where applicable.
+- Test credential strings use placeholders and `# nosec B105` where needed.
+
+For integration tests, apply `writing-integration-tests`:
+
+- Tests are named `test_*_integration.py` and marked `pytest.mark.integration`.
+- Destructive tests are marked `pytest.mark.destructive` and clean up data where possible.
+- `live_context` returns `FetchResponse` for SDK 2.x `context.fetch` paths.
+- Tests skip cleanly when credentials or required test IDs are missing.
+- Every env var read by `env_credentials(...)`, `os.environ.get(...)`, `os.getenv(...)`, `os.environ[...]`, or equivalent helpers is listed as a blank template entry in root `.env.example`.
+
+Missing `.env.example` entries are a should-fix at minimum, and often a blocker for PRs whose main purpose is adding/changing integration tests.
+
+### 6. SDK v2 upgrade review
+
+If the PR upgrades an integration to SDK 2.x or changes fetch handling, apply `upgrading-sdk-v2`:
+
+- `requirements.txt` pins `autohive-integrations-sdk~=2.0.0`.
+- `context.fetch()` results access `.data` for response body.
+- Unit/integration test fetch mocks return `FetchResponse`.
+- Error paths return `ActionError(message=...)` instead of success-shaped error data.
+- Error-only `error` / `result` fields are removed from success output schemas where applicable.
+- `config.json` version bump is appropriate for an existing integration upgrade.
+- Integration-test env vars remain documented in root `.env.example` if tests are touched.
+
+### 7. Documentation and metadata
+
+Check:
+
+- Integration `README.md` explains setup/auth, actions, requirements, usage examples, and testing notes.
+- Repo-level `README.md` is updated for new integrations.
+- `config.json` has clear descriptions, `display_name`, input/output schemas, auth config, and version.
+- New or changed integration tests document local run commands in the PR or README when helpful.
+- Icons are present and valid; no binary metadata concerns for public migrations.
+
+## Finding Severity
+
+Use these categories:
+
+- **🚫 Blocker** — must fix before merge. Security leaks, broken validation, schema/action mismatch, new integration input drift, missing required files, broken imports/tests, unsafe public migration.
+- **⚠️ Should-fix** — strongly recommended before merge. Missing `.env.example` entries, incomplete test coverage for changed behavior, unclear docs, overly broad error handling, avoidable warnings.
+- **💡 Suggestion** — optional improvements. Naming clarity, small refactors, additional examples, extra edge-case tests.
+
+## Review Output Template
+
+```markdown
+## Integration PR review
+
+Applied sub-skills: building-integration, writing-unit-tests, writing-integration-tests
+
+### 🚫 Blockers
+- [file:line] Issue and why it blocks merge. Suggested fix.
+
+### ⚠️ Should-fix
+- [file:line] Issue and recommended fix.
+
+### 💡 Suggestions
+- [file:line] Optional improvement.
+
+### Validation
+- Tooling run: `validate_integration.py ...` / `check_code.py ...` / `run_tests.py ...`
+- Tests run or inspected:
+- Not run:
+```
+
+If there are no findings in a category, say “None.” Do not invent issues just to fill the template.
+
+## Final Checklist
+
+Before completing the review, verify:
+
+- [ ] Relevant sub-skills were applied based on PR scope.
+- [ ] Security/secrets/public-safety review was performed.
+- [ ] Tooling/CI status was checked or local validation was run.
+- [ ] Config/code/schema sync was inspected.
+- [ ] Unit/integration test changes were reviewed against the appropriate test skill.
+- [ ] Root `.env.example` was checked when integration tests reference env vars.
+- [ ] Findings are actionable and severity-labelled.


### PR DESCRIPTION
## Summary

Adds a dedicated `reviewing-integration-prs` skill for structured reviews of Autohive integration PRs.

## What it covers

- General integration code quality and SDK usage
- Security, secrets, and public-safety review
- Config/code/schema consistency
- Unit and integration test review expectations
- `.env.example` checks for integration-test env vars
- SDK v2 upgrade checks when fetch handling or SDK pins change
- Migration review checks for private-to-public integrations

## Existing skills used as sub-skill checklists

The new review skill explicitly routes relevant PR contexts through:

- `building-integration`
- `writing-unit-tests`
- `writing-integration-tests`
- `upgrading-sdk-v2`
- `migrating-private-integration`

## Other updates

- Updates `skills/README.md` to list the new review skill.
- Adds the existing `migrating-private-integration` skill to the README skill table because it was missing.

## Validation

- `git diff --check`
